### PR TITLE
fix CPU initialization bug

### DIFF
--- a/src/xlora/xlora.py
+++ b/src/xlora/xlora.py
@@ -149,7 +149,7 @@ def add_xlora_to_model(
 
             model_peft.internal_xlora_scalings = torch.full(  # type: ignore
                 (payload.batch_size, payload.seq_len, xlora_classifier.n_layers, xlora_classifier.n_classes),
-                payload.override_scaling_pass_value,
+                payload.override_scaling_pass_value, device=kwargs_real['input_ids'].device
             )
 
             return


### PR DESCRIPTION
Hi, your work is highly valuable. It has been very helpful for my research.

**One small note**: The tensor initialized in this section is created on the CPU by default. This can lead to device mismatch errors in the following codes. 